### PR TITLE
Add discontinue action

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -36,6 +36,7 @@ class Products(db.Model):
     image_url = db.Column(db.String(1023))
     category = db.Column(db.String(63))
     availability = db.Column(db.Boolean, default=True, nullable=False)
+    discontinued = db.Column(db.Boolean, default=False, nullable=False)
     created_date = db.Column(
         db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
     )
@@ -98,6 +99,7 @@ class Products(db.Model):
             "image_url": self.image_url,
             "category": self.category,
             "availability": self.availability,
+            "discontinued": self.discontinued,
             "created_date": self.created_date,
             "updated_date": self.updated_date,
         }
@@ -116,6 +118,7 @@ class Products(db.Model):
             self.image_url = data["image_url"]
             self.category = data["category"]
             self.availability = data.get("availability", True)
+            self.discontinued = data.get("discontinued", False)
             self.created_date = data.get("created_date", datetime.now(timezone.utc))
             self.updated_date = data.get("updated_date", datetime.now(timezone.utc))
         except AttributeError as error:
@@ -139,7 +142,7 @@ class Products(db.Model):
     def all(cls):
         """Returns all of the Productss in the database"""
         logger.info("Processing all Productss")
-        return cls.query.all()
+        return cls.query.filter(cls.discontinued.is_(False)).all()
 
     @classmethod
     def find(cls, by_id):
@@ -155,7 +158,7 @@ class Products(db.Model):
             name (string): the name of the Productss you want to match
         """
         logger.info("Processing name query for %s ...", name)
-        return cls.query.filter(cls.name.ilike(f"%{name}%"))
+        return cls.query.filter(cls.discontinued.is_(False)).filter(cls.name.ilike(f"%{name}%"))
 
     @classmethod
     def find_by_category(cls, category: str) -> list:
@@ -169,7 +172,7 @@ class Products(db.Model):
 
         """
         logger.info("Processing category query for %s ...", category)
-        return cls.query.filter(cls.category.ilike(f"%{category}%"))
+        return cls.query.filter(cls.discontinued.is_(False)).filter(cls.category.ilike(f"%{category}%"))
 
     @classmethod
     def find_by_availability(cls, available: bool = True) -> list:
@@ -185,4 +188,4 @@ class Products(db.Model):
         if not isinstance(available, bool):
             raise TypeError("Invalid availability, must be of type boolean")
         logger.info("Processing available query for %s ...", available)
-        return cls.query.filter(cls.availability == available)
+        return cls.query.filter(cls.discontinued.is_(False)).filter(cls.availability == available)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -21,5 +21,6 @@ class ProductsFactory(factory.Factory):
     image_url = factory.Faker("image_url")
     category = factory.Faker("word")
     availability = factory.Faker("boolean")
+    discontinued = False
 
     # NOTE: Add other attributes here if/when needed for tests.


### PR DESCRIPTION
- Added a new endpoint `PUT /products/<id>/discontinue` to mark products as discontinued.

- Introduced is_discontinued field in Products model to support logical deletion.

- Updated model queries to exclude discontinued products.
